### PR TITLE
feat: Add BatchTokenConverterOperator with support for Permit2

### DIFF
--- a/packages/smart-contracts/contracts/flash-swap/FlashHandler.sol
+++ b/packages/smart-contracts/contracts/flash-swap/FlashHandler.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
 
+import { Token } from "../util/Token.sol";
 import { ISmartRouter } from "../third-party/pancakeswap-v8/ISmartRouter.sol";
 import { PoolAddress } from "../third-party/pancakeswap-v8/PoolAddress.sol";
 
@@ -35,7 +35,7 @@ abstract contract FlashHandler {
     /// @param data Application-specific data
     /// @return tokenIn Token X
     /// @return maxAmountIn Maximum amount of token X to be used to repay the flash operation
-    function _onMoneyReceived(bytes memory data) internal virtual returns (IERC20 tokenIn, uint256 maxAmountIn);
+    function _onMoneyReceived(bytes memory data) internal virtual returns (Token tokenIn, uint256 maxAmountIn);
 
     /// @dev Called when the flash operation is completed and was paid for. By default, does nothing.
     ///   Note that msg.sender is the pool that called the callback, not the original caller

--- a/packages/smart-contracts/contracts/operators/BatchTokenConverterOperator.sol
+++ b/packages/smart-contracts/contracts/operators/BatchTokenConverterOperator.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IAbstractTokenConverter } from "@venusprotocol/protocol-reserve/contracts/TokenConverter/IAbstractTokenConverter.sol";
+
+import { FlashHandler } from "../flash-swap/FlashHandler.sol";
+import { ExactOutputFlashSwap } from "../flash-swap/ExactOutputFlashSwap.sol";
+import { Token } from "../util/Token.sol";
+import { DelegateMulticall } from "../util/DelegateMulticall.sol";
+import { checkDeadline as _checkDeadline, validatePath } from "../util/validators.sol";
+import { ISmartRouter } from "../third-party/pancakeswap-v8/ISmartRouter.sol";
+import { ISignatureTransfer } from "../third-party/permit2/ISignatureTransfer.sol";
+
+/// @title BatchTokenConverterOperator
+/// @notice Converts tokens in a TokenConverter using an exact-output flash swap,
+///   allowing for batch calls via multicall and permit2-style approvals.
+///   Note that this contract is NOT designed to be operational outside of a single
+///   transaction, e.g. anyone can withdraw all of its token holdings, so it's
+///   important to use convert(...) and claimAll(...) in one transaction via batch().
+///   See `DelegateMulticall` documentation for more detais on how to use this
+///   contract securely.
+/// @dev Conversions happen similar to TokenConverterOperator
+contract BatchTokenConverterOperator is ExactOutputFlashSwap, DelegateMulticall {
+    using SafeERC20 for IERC20;
+
+    /// @notice Conversion parameters
+    struct ConversionParameters {
+        /// @notice The token currently in the TokenConverter
+        Token tokenToReceiveFromConverter;
+        /// @notice The amount (in `tokenToReceiveFromConverter` tokens) to receive as a result of conversion
+        uint256 amount;
+        /// @notice Minimal income to get from the arbitrage transaction (in `tokenToReceiveFromConverter`).
+        ///   This value can be negative to indicate that the sender is willing to pay for the transaction
+        ///   execution. In this case, a `sponsorWithPermit(...)` call should be made before the conversion.
+        int256 minIncome;
+        /// @notice The token the TokenConverter would get
+        Token tokenToSendToConverter;
+        /// @notice Address of the token converter contract to arbitrage
+        IAbstractTokenConverter converter;
+        /// @notice Reversed (exact output) path to trade from `tokenToReceiveFromConverter`
+        /// to `tokenToSendToConverter`
+        bytes path;
+    }
+
+    /// @notice Conversion data to pass between calls
+    struct ConversionData {
+        /// @notice The token the TokenConverter would receive
+        Token tokenToSendToConverter;
+        /// @notice The amount (in `amountToSendToConverter` tokens) to send to converter
+        uint256 amountToSendToConverter;
+        /// @notice The token currently in the TokenConverter
+        Token tokenToReceiveFromConverter;
+        /// @notice The amount (in `tokenToReceiveFromConverter` tokens) to receive
+        uint256 amountToReceiveFromConverter;
+        /// @notice Minimal income to get from the arbitrage transaction (in `amountToReceiveFromConverter`).
+        int256 minIncome;
+        /// @notice Address of the token converter contract to arbitrage
+        IAbstractTokenConverter converter;
+    }
+
+    ISignatureTransfer public immutable PERMIT2;
+
+    /// @notice Thrown if the amount of to receive from TokenConverter is less than expected
+    /// @param expected Expected amount of tokens
+    /// @param actual Actual amount of tokens
+    error InsufficientLiquidity(uint256 expected, uint256 actual);
+
+    /// @notice Thrown on math underflow
+    error Underflow();
+
+    /// @notice Thrown on math overflow
+    error Overflow();
+
+    /// @param swapRouter_ PancakeSwap SmartRouter contract
+    // solhint-disable-next-line no-empty-blocks
+    constructor(ISmartRouter swapRouter_, ISignatureTransfer permit2_) FlashHandler(swapRouter_) {
+        PERMIT2 = permit2_;
+    }
+
+    /// @notice Transfers the specified token amounts from sender to this contract
+    /// @param permit Permit2-style batch transfer permit
+    /// @param signature Permit signature
+    function sponsorWithPermit(
+        ISignatureTransfer.PermitBatchTransferFrom calldata permit,
+        bytes calldata signature
+    ) external {
+        uint256 tokensCount = permit.permitted.length;
+        ISignatureTransfer.SignatureTransferDetails[]
+            memory transferDetails = new ISignatureTransfer.SignatureTransferDetails[](tokensCount);
+        for (uint256 i; i < tokensCount; ++i) {
+            transferDetails[i] = ISignatureTransfer.SignatureTransferDetails({
+                to: address(this),
+                requestedAmount: permit.permitted[i].amount
+            });
+        }
+        PERMIT2.permitTransferFrom(permit, transferDetails, msg.sender, signature);
+    }
+
+    /// @notice Same as convert(...) but does not perform the deadline check
+    /// @param params Conversion parameters
+    function convert(ConversionParameters calldata params) external {
+        validatePath(params.path, params.tokenToSendToConverter.addr(), params.tokenToReceiveFromConverter.addr());
+
+        (uint256 amountToReceive, uint256 amountToPay) = params.converter.getUpdatedAmountIn(
+            params.amount,
+            params.tokenToSendToConverter.addr(),
+            params.tokenToReceiveFromConverter.addr()
+        );
+        if (params.amount != amountToReceive) {
+            revert InsufficientLiquidity(params.amount, amountToReceive);
+        }
+
+        ConversionData memory data = ConversionData({
+            tokenToSendToConverter: params.tokenToSendToConverter,
+            amountToSendToConverter: amountToPay,
+            tokenToReceiveFromConverter: params.tokenToReceiveFromConverter,
+            amountToReceiveFromConverter: amountToReceive,
+            minIncome: params.minIncome,
+            converter: params.converter
+        });
+
+        _flashSwap(amountToPay, params.path, abi.encode(data));
+    }
+
+    /// @notice Claim refund or income to beneficiary
+    /// @param token ERC-20 token address
+    /// @param amount Amount to transfer
+    /// @param beneficiary Receiver of the token
+    function claimTo(Token token, uint256 amount, address beneficiary) external {
+        token.transfer(beneficiary, amount);
+    }
+
+    /// @notice Claim the entire token balance to beneficiary
+    /// @param token ERC-20 token address
+    /// @param beneficiary Receiver of the token
+    function claimAllTo(Token token, address beneficiary) external {
+        token.transferAll(beneficiary);
+    }
+
+    /// @notice Reverts if transaction execution deadline has passed
+    /// @param deadline Deadline timestamp
+    function checkDeadline(uint256 deadline) external view {
+        _checkDeadline(deadline);
+    }
+
+    function _onMoneyReceived(bytes memory data) internal override returns (Token tokenIn, uint256 maxAmountIn) {
+        ConversionData memory decoded = abi.decode(data, (ConversionData));
+
+        uint256 receivedAmount = _convertViaTokenConverter(
+            decoded.converter,
+            decoded.tokenToSendToConverter,
+            decoded.tokenToReceiveFromConverter,
+            decoded.amountToReceiveFromConverter
+        );
+
+        return (decoded.tokenToReceiveFromConverter, _u(_i(receivedAmount) - decoded.minIncome));
+    }
+
+    /// @dev Get `tokenToReceive` from TokenConverter, paying with `tokenToPay`
+    /// @param converter TokenConverter contract
+    /// @param tokenToPay Token to be sent to TokenConverter
+    /// @param tokenToReceive Token to be received from TokenConverter
+    /// @param amountToReceive Amount to receive from TokenConverter in `tokenToReceive` tokens
+    function _convertViaTokenConverter(
+        IAbstractTokenConverter converter,
+        Token tokenToPay,
+        Token tokenToReceive,
+        uint256 amountToReceive
+    ) internal returns (uint256) {
+        uint256 balanceBefore = tokenToReceive.balanceOf(address(this));
+        uint256 maxAmountToPay = tokenToPay.balanceOf(address(this));
+
+        tokenToPay.approve(address(converter), maxAmountToPay);
+        converter.convertForExactTokens(
+            maxAmountToPay,
+            amountToReceive,
+            tokenToPay.addr(),
+            tokenToReceive.addr(),
+            address(this)
+        );
+        tokenToPay.approve(address(converter), 0);
+        uint256 tokensReceived = tokenToReceive.balanceOf(address(this)) - balanceBefore;
+        return tokensReceived;
+    }
+
+    function _u(int256 value) private pure returns (uint256) {
+        if (value < 0) {
+            revert Underflow();
+        }
+        return uint256(value);
+    }
+
+    function _i(uint256 value) private pure returns (int256) {
+        if (value > uint256(type(int256).max)) {
+            revert Overflow();
+        }
+        return int256(value);
+    }
+}

--- a/packages/smart-contracts/contracts/third-party/permit2/IEIP712.sol
+++ b/packages/smart-contracts/contracts/third-party/permit2/IEIP712.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IEIP712 {
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/packages/smart-contracts/contracts/third-party/permit2/ISignatureTransfer.sol
+++ b/packages/smart-contracts/contracts/third-party/permit2/ISignatureTransfer.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IEIP712} from "./IEIP712.sol";
+
+/// @title SignatureTransfer
+/// @notice Handles ERC20 token transfers through signature based actions
+/// @dev Requires user's token approval on the Permit2 contract
+interface ISignatureTransfer is IEIP712 {
+    /// @notice Thrown when the requested amount for a transfer is larger than the permissioned amount
+    /// @param maxAmount The maximum amount a spender can request to transfer
+    error InvalidAmount(uint256 maxAmount);
+
+    /// @notice Thrown when the number of tokens permissioned to a spender does not match the number of tokens being transferred
+    /// @dev If the spender does not need to transfer the number of tokens permitted, the spender can request amount 0 to be transferred
+    error LengthMismatch();
+
+    /// @notice Emits an event when the owner successfully invalidates an unordered nonce.
+    event UnorderedNonceInvalidation(address indexed owner, uint256 word, uint256 mask);
+
+    /// @notice The token and amount details for a transfer signed in the permit transfer signature
+    struct TokenPermissions {
+        // ERC20 token address
+        address token;
+        // the maximum amount that can be spent
+        uint256 amount;
+    }
+
+    /// @notice The signed permit message for a single token transfer
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        // a unique value for every token owner's signature to prevent signature replays
+        uint256 nonce;
+        // deadline on the permit signature
+        uint256 deadline;
+    }
+
+    /// @notice Specifies the recipient address and amount for batched transfers.
+    /// @dev Recipients and amounts correspond to the index of the signed token permissions array.
+    /// @dev Reverts if the requested amount is greater than the permitted signed amount.
+    struct SignatureTransferDetails {
+        // recipient address
+        address to;
+        // spender requested amount
+        uint256 requestedAmount;
+    }
+
+    /// @notice Used to reconstruct the signed permit message for multiple token transfers
+    /// @dev Do not need to pass in spender address as it is required that it is msg.sender
+    /// @dev Note that a user still signs over a spender address
+    struct PermitBatchTransferFrom {
+        // the tokens and corresponding amounts permitted for a transfer
+        TokenPermissions[] permitted;
+        // a unique value for every token owner's signature to prevent signature replays
+        uint256 nonce;
+        // deadline on the permit signature
+        uint256 deadline;
+    }
+
+    /// @notice A map from token owner address and a caller specified word index to a bitmap. Used to set bits in the bitmap to prevent against signature replay protection
+    /// @dev Uses unordered nonces so that permit messages do not need to be spent in a certain order
+    /// @dev The mapping is indexed first by the token owner, then by an index specified in the nonce
+    /// @dev It returns a uint256 bitmap
+    /// @dev The index, or wordPosition is capped at type(uint248).max
+    function nonceBitmap(address, uint256) external view returns (uint256);
+
+    /// @notice Transfers a token using a signed permit message
+    /// @dev Reverts if the requested amount is greater than the permitted signed amount
+    /// @param permit The permit data signed over by the owner
+    /// @param owner The owner of the tokens to transfer
+    /// @param transferDetails The spender's requested transfer details for the permitted token
+    /// @param signature The signature to verify
+    function permitTransferFrom(
+        PermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Transfers a token using a signed permit message
+    /// @notice Includes extra data provided by the caller to verify signature over
+    /// @dev The witness type string must follow EIP712 ordering of nested structs and must include the TokenPermissions type definition
+    /// @dev Reverts if the requested amount is greater than the permitted signed amount
+    /// @param permit The permit data signed over by the owner
+    /// @param owner The owner of the tokens to transfer
+    /// @param transferDetails The spender's requested transfer details for the permitted token
+    /// @param witness Extra data to include when checking the user signature
+    /// @param witnessTypeString The EIP-712 type definition for remaining string stub of the typehash
+    /// @param signature The signature to verify
+    function permitWitnessTransferFrom(
+        PermitTransferFrom memory permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32 witness,
+        string calldata witnessTypeString,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Transfers multiple tokens using a signed permit message
+    /// @param permit The permit data signed over by the owner
+    /// @param owner The owner of the tokens to transfer
+    /// @param transferDetails Specifies the recipient and requested amount for the token transfer
+    /// @param signature The signature to verify
+    function permitTransferFrom(
+        PermitBatchTransferFrom memory permit,
+        SignatureTransferDetails[] calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Transfers multiple tokens using a signed permit message
+    /// @dev The witness type string must follow EIP712 ordering of nested structs and must include the TokenPermissions type definition
+    /// @notice Includes extra data provided by the caller to verify signature over
+    /// @param permit The permit data signed over by the owner
+    /// @param owner The owner of the tokens to transfer
+    /// @param transferDetails Specifies the recipient and requested amount for the token transfer
+    /// @param witness Extra data to include when checking the user signature
+    /// @param witnessTypeString The EIP-712 type definition for remaining string stub of the typehash
+    /// @param signature The signature to verify
+    function permitWitnessTransferFrom(
+        PermitBatchTransferFrom memory permit,
+        SignatureTransferDetails[] calldata transferDetails,
+        address owner,
+        bytes32 witness,
+        string calldata witnessTypeString,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Invalidates the bits specified in mask for the bitmap at the word position
+    /// @dev The wordPos is maxed at type(uint248).max
+    /// @param wordPos A number to index the nonceBitmap at
+    /// @param mask A bitmap masked against msg.sender's current bitmap at the word position
+    function invalidateUnorderedNonces(uint256 wordPos, uint256 mask) external;
+}

--- a/packages/smart-contracts/contracts/util/DelegateMulticall.sol
+++ b/packages/smart-contracts/contracts/util/DelegateMulticall.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+/// @title DelegateMulticall
+/// @notice A base contract that allows the integrations to delegatecall into the current
+///   contract or make regular calls to any contract in a batch fashion. Note that inheriting
+///   from DelegateMulticall makes the contract useful for a SINGLE TRANSACTION ONLY.
+///   Since the sender can directly request the contract to perform any call, e.g., transfer
+///   ERC-20 tokens or execute a permissioned action, it is NOT SAFE to grant ANY permissions
+///   to the inheriting contract or store any tokens (apart from within a single tx) in the
+///   inheriting contract. This contract is NOT reentrancy-safe, i.e. the receiver of any
+///   call can reenter into the calling contract. Thus, the caller MUST ensure that they're
+///   only interacting with the known contracts.
+contract DelegateMulticall {
+    struct Call {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    error CallFailed(uint256 callIndex, bytes err);
+
+    function batch(Call[] calldata calls) external returns (Result[] memory returnData) {
+        uint256 length = calls.length;
+        returnData = new Result[](length);
+        Call calldata call;
+        for (uint256 i = 0; i < length; ++i) {
+            Result memory result = returnData[i];
+            call = calls[i];
+            if (call.target == address(0)) {
+                (result.success, result.returnData) = address(this).delegatecall(call.callData);
+            } else {
+                (result.success, result.returnData) = call.target.call(call.callData);
+            }
+            if (!result.success && !call.allowFailure) {
+                revert CallFailed(i, result.returnData);
+            }
+        }
+    }
+}

--- a/packages/smart-contracts/contracts/util/Token.sol
+++ b/packages/smart-contracts/contracts/util/Token.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.25;
+
+// A utility library for handling token transfers. Instead of extending IERC20 interface,
+// introduces a new `Token` type with most of the operations "done right", e.g. it uses
+// a reverting version of `approve` and `transfer`. It also has some utility methods like
+// balanceOfSelf and transferAll that has proven to be useful in our contracts.
+//
+// The library exposes addr() and ierc20() methods to simplify the conversion to
+// other kinds of ERC20 token types commonly used in contracts.
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { approveOrRevert } from "./approveOrRevert.sol";
+
+type Token is address;
+
+library TokenLibrary {
+    using TokenLibrary for Token;
+    using SafeERC20 for IERC20;
+
+    /**
+     * @dev Approves the specified amount or reverts. Handles non-compliant tokens.
+     * @param token Token
+     * @param spender The account approved to spend the tokens
+     * @param amount The approved amount
+     */
+    function approve(Token token, address spender, uint256 amount) internal {
+        approveOrRevert(IERC20(token.addr()), spender, amount);
+    }
+
+    /**
+     * @dev Wrapper for SafeERC20.safeTransfer
+     * @param token Token
+     * @param receiver The account that would receive the tokens
+     * @param amount The amount to transfer
+     */
+    function transfer(Token token, address receiver, uint256 amount) internal {
+        token.ierc20().safeTransfer(receiver, amount);
+    }
+
+    /**
+     * @dev Wrapper for SafeERC20.safeTransferFrom
+     * @param token Token
+     * @param receiver The account that would receive the tokens
+     * @param amount The amount to transfer
+     */
+    function transferFrom(Token token, address payer, address receiver, uint256 amount) internal {
+        token.ierc20().safeTransferFrom(payer, receiver, amount);
+    }
+
+    /**
+     * @dev Transfer from payer to address(this)
+     * @param token Token
+     * @param amount The amount to transfer
+     */
+    function transferToSelf(Token token, address payer, uint256 amount) internal {
+        token.transferFrom(payer, address(this), amount);
+    }
+
+    /**
+     * @dev Transfers the entire contract's balance to the receiver
+     * @param token Token
+     * @param receiver The account that would receive the tokens
+     */
+    function transferAll(Token token, address receiver) internal {
+        uint256 balance = token.balanceOfSelf();
+        if (balance > 0) {
+            token.transfer(receiver, balance);
+        }
+    }
+
+    function balanceOf(Token token, address account) internal view returns (uint256) {
+        return token.ierc20().balanceOf(account);
+    }
+
+    function balanceOfSelf(Token token) internal view returns (uint256) {
+        return token.balanceOf(address(this));
+    }
+
+    function addr(Token token) internal pure returns (address) {
+        return Token.unwrap(token);
+    }
+
+    function ierc20(Token token) internal pure returns (IERC20) {
+        return IERC20(token.addr());
+    }
+}
+
+using TokenLibrary for Token global;
+
+function eq(Token a, Token b) pure returns (bool) {
+    return a.addr() == b.addr();
+}
+
+function neq(Token a, Token b) pure returns (bool) {
+    return a.addr() != b.addr();
+}
+
+using { eq as == } for Token global;
+using { neq as != } for Token global;

--- a/packages/smart-contracts/fork-tests/BatchTokenConverterOperator.ts
+++ b/packages/smart-contracts/fork-tests/BatchTokenConverterOperator.ts
@@ -1,0 +1,222 @@
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { PERMIT2_ADDRESS, SignatureTransfer, TokenPermissions } from "@uniswap/permit2-sdk";
+import { SingleTokenConverter__factory } from "@venusprotocol/protocol-reserve/dist/typechain/factories/SingleTokenConverter__factory";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { concat, hexlify, parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import {
+  BatchTokenConverterOperator,
+  BatchTokenConverterOperator__factory,
+  IERC20__factory,
+  ISignatureTransfer__factory,
+} from "../typechain";
+import ADDRESSES from "./config/addresses";
+import { connect, deploy, faucet, forking, getBlockTimestamp, initUser } from "./framework";
+
+interface TokenConverterOperatorFixture {
+  operator: BatchTokenConverterOperator;
+}
+
+const makePath = (parts: string[]) => hexlify(concat(parts));
+
+const negate = (value: BigNumber) => BigNumber.from(0).sub(value);
+
+forking({ bsctestnet: 37472590, bscmainnet: 35878500 } as const, network => {
+  const addresses = ADDRESSES[network];
+
+  describe("TokenConverterOperator", () => {
+    const xvs = connect(IERC20__factory, addresses.XVS);
+    const usdt = connect(IERC20__factory, addresses.USDT);
+    const converter = connect(SingleTokenConverter__factory, addresses.XVSVaultConverter);
+    const permit2 = connect(ISignatureTransfer__factory, PERMIT2_ADDRESS);
+    const usdtDecimals = {
+      bsctestnet: 6,
+      bscmainnet: 18,
+    }[network];
+    const usdtToReceive = parseUnits("100", usdtDecimals);
+    const minIncome = parseUnits("-5", usdtDecimals);
+    const sponsorAmount = negate(minIncome);
+    const path = {
+      bsctestnet: makePath([addresses.XVS, "0x0001f4", addresses.USDT]),
+      bscmainnet: makePath([addresses.XVS, "0x0009c4", addresses.WBNB, "0x000064", addresses.USDT]),
+    }[network];
+
+    let operator: BatchTokenConverterOperator;
+    let root: SignerWithAddress;
+    let beneficiary: SignerWithAddress;
+    let now: number;
+    let deadline: number;
+    let chainId: number;
+
+    const tokenConverterOperatorFixture = async (): Promise<TokenConverterOperatorFixture> => {
+      const [root] = await ethers.getSigners();
+      await faucet(xvs, addresses.xvsHolder, root, parseUnits("10000", 18));
+      await faucet(usdt, addresses.usdtHolder, root, parseUnits("10000", usdtDecimals));
+      await usdt.connect(root).approve(permit2.address, ethers.constants.MaxUint256);
+      const operator = await deploy(BatchTokenConverterOperator__factory, addresses.PancakeSwapRouter, PERMIT2_ADDRESS);
+      return { operator };
+    };
+
+    beforeEach(async () => {
+      [root, beneficiary] = await ethers.getSigners();
+      ({ operator } = await loadFixture(tokenConverterOperatorFixture));
+
+      now = await getBlockTimestamp();
+      deadline = now + 6000;
+      chainId = (await ethers.provider.getNetwork()).chainId;
+      const timelock = await initUser(addresses.NormalTimelock);
+      await converter
+        .connect(timelock)
+        .setConversionConfigs(addresses.XVS, [addresses.USDT], [{ incentive: 0, conversionAccess: 1 }]);
+      await usdt.connect(root).transfer(converter.address, usdtToReceive);
+      await converter.connect(root).updateAssetsState(addresses.Unitroller, addresses.USDT);
+    });
+
+    const makeCommonParams = () => ({
+      tokenToReceiveFromConverter: addresses.USDT,
+      beneficiary: beneficiary.address,
+      amount: usdtToReceive,
+      minIncome: minIncome,
+      tokenToSendToConverter: addresses.XVS,
+      converter: addresses.XVSVaultConverter,
+      path,
+    });
+
+    const makePermit = async (permitted: TokenPermissions[], nonce: number) => {
+      const permit = {
+        permitted,
+        spender: operator.address,
+        nonce,
+        deadline,
+      };
+      const { domain, types, values } = SignatureTransfer.getPermitData(permit, PERMIT2_ADDRESS, chainId);
+      const signature = await root._signTypedData(domain, types, values);
+      return { permit, signature };
+    };
+
+    describe("individual calls", () => {
+      describe("checkDeadline", () => {
+        it("succeeds if deadline is in the future", async () => {
+          await operator.checkDeadline(deadline);
+        });
+
+        it("succeeds if deadline is in the past", async () => {
+          await expect(operator.checkDeadline(now))
+            .to.be.revertedWithCustomError(operator, "DeadlinePassed")
+            .withArgs(anyValue, now);
+        });
+      });
+
+      describe("sponsorWithPermit", () => {
+        it("can be sponsored by permit", async () => {
+          const { permit, signature } = await makePermit([{ token: usdt.address, amount: sponsorAmount }], 1);
+          const tx = await operator.connect(root).sponsorWithPermit(permit, signature);
+          await expect(tx).to.changeTokenBalances(usdt, [root, operator], [negate(sponsorAmount), sponsorAmount]);
+        });
+      });
+
+      describe("convert", () => {
+        beforeEach(async () => {
+          await usdt.connect(root).transfer(operator.address, sponsorAmount);
+        });
+
+        it("fails if path start != token to send to converter", async () => {
+          const wrongPath = makePath([addresses.USDT, "0x0001f4", addresses.XVS]);
+          const tx = operator.connect(root).convert({ ...makeCommonParams(), path: wrongPath });
+          await expect(tx)
+            .to.be.revertedWithCustomError(operator, "InvalidSwapStart")
+            .withArgs(addresses.XVS, addresses.USDT);
+        });
+
+        it("fails if path end != token to receive from converter", async () => {
+          const wrongPath = makePath([addresses.XVS, "0x0009c4", addresses.WBNB]);
+          const tx = operator.connect(root).convert({ ...makeCommonParams(), path: wrongPath });
+          await expect(tx)
+            .to.be.revertedWithCustomError(operator, "InvalidSwapEnd")
+            .withArgs(addresses.USDT, addresses.WBNB);
+        });
+
+        it("transfers USDT from the token converter", async () => {
+          const tx = await operator.connect(root).convert(makeCommonParams());
+          await expect(tx).to.emit(usdt, "Transfer").withArgs(converter.address, operator.address, usdtToReceive);
+        });
+
+        it("transfers XVS to the token converter", async () => {
+          const tx = await operator.connect(root).convert(makeCommonParams());
+          await expect(tx).to.emit(xvs, "Transfer").withArgs(operator.address, anyValue, anyValue);
+        });
+
+        it("keeps USDT in the operator contract", async () => {
+          await operator.connect(root).convert(makeCommonParams());
+          expect(await usdt.balanceOf(operator.address)).to.be.gt(0);
+        });
+      });
+    });
+
+    describe("batch calls", () => {
+      const delegateToSelf = (
+        callData: string,
+        { allowFailure }: { allowFailure: boolean } = { allowFailure: false },
+      ) => ({
+        target: ethers.constants.AddressZero,
+        allowFailure,
+        callData,
+      });
+
+      it("reverts if the call was requested to succeed but it didn't", async () => {
+        const tooEarly = now;
+        const tx = operator
+          .connect(root)
+          .batch([delegateToSelf(operator.interface.encodeFunctionData("checkDeadline", [tooEarly]))]);
+        await expect(tx).to.be.revertedWithCustomError(operator, "CallFailed").withArgs(0, anyValue);
+      });
+
+      it("returns error result if one of the call fails but errors are allowed", async () => {
+        const tooEarly = now;
+        const result = await operator.connect(root).callStatic.batch([
+          delegateToSelf(operator.interface.encodeFunctionData("checkDeadline", [deadline]), { allowFailure: true }), // ok
+          delegateToSelf(operator.interface.encodeFunctionData("checkDeadline", [tooEarly]), { allowFailure: true }), // fails
+        ]);
+        expect(result).to.have.lengthOf(2);
+        expect(result[0].success).to.be.true;
+        expect(result[0].returnData).to.equal("0x");
+        expect(result[1].success).to.be.false;
+        const errorResult = operator.interface.decodeErrorResult("DeadlinePassed", result[1].returnData);
+        expect(errorResult.deadline).to.equal(tooEarly);
+      });
+
+      it("executes the full conversion in a batch fashion", async () => {
+        const { permit, signature } = await makePermit([{ token: usdt.address, amount: sponsorAmount }], 1);
+        await operator
+          .connect(root)
+          .batch([
+            delegateToSelf(operator.interface.encodeFunctionData("checkDeadline", [deadline])),
+            delegateToSelf(operator.interface.encodeFunctionData("sponsorWithPermit", [permit, signature])),
+            delegateToSelf(operator.interface.encodeFunctionData("convert", [makeCommonParams()])),
+            delegateToSelf(operator.interface.encodeFunctionData("claimAllTo", [usdt.address, root.address])),
+          ]);
+      });
+
+      it("returns success for each call", async () => {
+        const { permit, signature } = await makePermit([{ token: usdt.address, amount: sponsorAmount }], 1);
+        const results = await operator
+          .connect(root)
+          .callStatic.batch([
+            delegateToSelf(operator.interface.encodeFunctionData("checkDeadline", [deadline])),
+            delegateToSelf(operator.interface.encodeFunctionData("sponsorWithPermit", [permit, signature])),
+            delegateToSelf(operator.interface.encodeFunctionData("convert", [makeCommonParams()])),
+            delegateToSelf(operator.interface.encodeFunctionData("claimAllTo", [usdt.address, root.address])),
+          ]);
+        expect(results).to.have.lengthOf(4);
+        results.forEach(result => {
+          expect(result.success).to.be.true;
+          expect(result.returnData).to.equal("0x");
+        });
+      });
+    });
+  });
+});

--- a/packages/smart-contracts/package.json
+++ b/packages/smart-contracts/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "4.9.3",
     "@openzeppelin/contracts-upgradeable": "4.9.3",
+    "@uniswap/permit2-sdk": "^1.2.1",
     "@venusprotocol/governance-contracts": "^2.0.0",
     "@venusprotocol/isolated-pools": "^3.3.0",
     "@venusprotocol/protocol-reserve": "^2.3.0-dev.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6639,6 +6639,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uniswap/permit2-sdk@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@uniswap/permit2-sdk@npm:1.2.1"
+  dependencies:
+    ethers: ^5.7.0
+    tiny-invariant: ^1.1.0
+  checksum: 7c4fcc0aaa6e53da0f01c25984b7b37aaf95aa43479a2f374d5867956033ed34d9477b31aa1c0998c51ae3af28ab5dd2902c97f2acd176dac6dfed171ca5b6a4
+  languageName: node
+  linkType: hard
+
 "@urql/core@npm:^3.2.0":
   version: 3.2.2
   resolution: "@urql/core@npm:3.2.2"
@@ -6709,7 +6719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/isolated-pools@npm:^3.3.0":
+"@venusprotocol/isolated-pools@npm:^3.0.0, @venusprotocol/isolated-pools@npm:^3.3.0":
   version: 3.3.0
   resolution: "@venusprotocol/isolated-pools@npm:3.3.0"
   dependencies:
@@ -6726,7 +6736,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/keeper-bot-contracts@^1.1.0-dev.1, @venusprotocol/keeper-bot-contracts@workspace:packages/smart-contracts":
+"@venusprotocol/keeper-bot-contracts@npm:^1.0.0, @venusprotocol/keeper-bot-contracts@npm:^1.1.0-dev.1":
+  version: 1.1.0
+  resolution: "@venusprotocol/keeper-bot-contracts@npm:1.1.0"
+  dependencies:
+    "@openzeppelin/contracts": 4.9.3
+    "@openzeppelin/contracts-upgradeable": 4.9.3
+    "@venusprotocol/governance-contracts": ^2.0.0
+    "@venusprotocol/isolated-pools": ^3.0.0
+    "@venusprotocol/protocol-reserve": ^2.0.0
+    "@venusprotocol/venus-protocol": ^8.0.0
+  checksum: 6f668b9b0e7f2d8893c7c513519e47cb9905fc1d9d2b1aaa63e485cf2f78a1272f0dc0a881075cde6f94fe95f81c3c1134519666434d47d480e009e1f5dd7cf6
+  languageName: node
+  linkType: hard
+
+"@venusprotocol/keeper-bot-contracts@workspace:packages/smart-contracts":
   version: 0.0.0-use.local
   resolution: "@venusprotocol/keeper-bot-contracts@workspace:packages/smart-contracts"
   dependencies:
@@ -6746,6 +6770,7 @@ __metadata:
     "@types/node": ^20.10.0
     "@typescript-eslint/eslint-plugin": ^6.13.1
     "@typescript-eslint/parser": ^6.13.1
+    "@uniswap/permit2-sdk": ^1.2.1
     "@venusprotocol/governance-contracts": ^2.0.0
     "@venusprotocol/isolated-pools": ^3.3.0
     "@venusprotocol/protocol-reserve": ^2.3.0-dev.1
@@ -6800,6 +6825,27 @@ __metadata:
     ts-node: ^10.9.2
   languageName: unknown
   linkType: soft
+
+"@venusprotocol/oracle@npm:^1.7.3":
+  version: 1.10.0
+  resolution: "@venusprotocol/oracle@npm:1.10.0"
+  dependencies:
+    "@chainlink/contracts": ^0.5.1
+    "@defi-wonderland/smock": ^2.3.4
+    "@nomicfoundation/hardhat-network-helpers": ^1.0.8
+    "@openzeppelin/contracts": ^4.6.0
+    "@openzeppelin/contracts-upgradeable": ^4.7.3
+    "@venusprotocol/governance-contracts": ^1.4.0
+    "@venusprotocol/solidity-utilities": 1.3.0
+    "@venusprotocol/venus-protocol": ^6.0.0
+    ethers: ^5.6.8
+    hardhat: ^2.16.1
+    hardhat-deploy: ^0.11.14
+    module-alias: ^2.2.2
+    solidity-docgen: ^0.6.0-beta.29
+  checksum: 44de308a3ba728e094b11de0da776dc53690601e9e462c83c087c6c3cb8cedb49d2b4cdda4c8a6dc215d9884369a3e99b11fed1d41d4fe9108d35fc7ff0e893d
+  languageName: node
+  linkType: hard
 
 "@venusprotocol/oracle@npm:^2.0.0":
   version: 2.3.0
@@ -6875,6 +6921,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@venusprotocol/solidity-utilities@npm:1.3.0, @venusprotocol/solidity-utilities@npm:^1.1.0, @venusprotocol/solidity-utilities@npm:^1.2.0, @venusprotocol/solidity-utilities@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@venusprotocol/solidity-utilities@npm:1.3.0"
+  checksum: d1109365a5e01959c47b25fb129373db93792e60bf1bc0ed324b63c2a64f6e4a7878ebf016cfade94bc41a2c1245d3e861fdc6b8c5844ac210ed1d73e7307e72
+  languageName: node
+  linkType: hard
+
 "@venusprotocol/solidity-utilities@npm:2.0.0":
   version: 2.0.0
   resolution: "@venusprotocol/solidity-utilities@npm:2.0.0"
@@ -6882,14 +6935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/solidity-utilities@npm:^1.1.0, @venusprotocol/solidity-utilities@npm:^1.2.0, @venusprotocol/solidity-utilities@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@venusprotocol/solidity-utilities@npm:1.3.0"
-  checksum: d1109365a5e01959c47b25fb129373db93792e60bf1bc0ed324b63c2a64f6e4a7878ebf016cfade94bc41a2c1245d3e861fdc6b8c5844ac210ed1d73e7307e72
-  languageName: node
-  linkType: hard
-
-"@venusprotocol/solidity-utilities@npm:^2.0.0, @venusprotocol/solidity-utilities@npm:^2.0.3":
+"@venusprotocol/solidity-utilities@npm:^2.0.0, @venusprotocol/solidity-utilities@npm:^2.0.1, @venusprotocol/solidity-utilities@npm:^2.0.3":
   version: 2.0.3
   resolution: "@venusprotocol/solidity-utilities@npm:2.0.3"
   checksum: 5f196d61989e1b276b6f2d515c0410f3af07deee9bec58a6657e61d46b1810b2da6e2880d1ec737fd410f23a035c2db47b6a3ab2274cac229cabfcf03d4424ac
@@ -6926,7 +6972,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/token-converter-bot@1.0.5, @venusprotocol/token-converter-bot@workspace:packages/token-converter-bot":
+"@venusprotocol/token-converter-bot@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@venusprotocol/token-converter-bot@npm:1.0.5"
+  dependencies:
+    "@graphprotocol/client-cli": 3.0.0
+    "@pancakeswap/sdk": ^5.8.0
+    "@pancakeswap/smart-router": ^5.1.3
+    "@pancakeswap/v3-core": ^1.0.2
+    "@venusprotocol/keeper-bot-contracts": ^1.0.0
+    "@venusprotocol/oracle": ^1.7.3
+    "@wagmi/cli": ^2.0.4
+    abitype: 0.10.0
+    graphql: ^16.8.1
+    hardhat: ^2.19.5
+    urql: ^3.0.3
+    viem: ^2.7.1
+    winston: ^3.11.0
+  checksum: 088467556182afde22ff72a07edf0d0b538a5039e37d745181c8e6a8c016e616284c7bb7aefa6eda73da05b02138620f5d3996a6f91f816512221bb742de526d
+  languageName: node
+  linkType: hard
+
+"@venusprotocol/token-converter-bot@workspace:packages/token-converter-bot":
   version: 0.0.0-use.local
   resolution: "@venusprotocol/token-converter-bot@workspace:packages/token-converter-bot"
   dependencies:
@@ -6994,6 +7061,24 @@ __metadata:
     dotenv: ^16.0.1
     module-alias: ^2.2.2
   checksum: 0a39304b6f2e0db05a20dacf6d678f3245be878a121e7d1ddeb503c28974dea9cbec0228be3d03f77abb97d1adb8e6e8ad8708cb730a5833e62c4e6735fb6eea
+  languageName: node
+  linkType: hard
+
+"@venusprotocol/venus-protocol@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "@venusprotocol/venus-protocol@npm:8.1.0"
+  dependencies:
+    "@nomicfoundation/hardhat-ethers": ^3.0.0
+    "@openzeppelin/contracts": 4.9.3
+    "@openzeppelin/contracts-upgradeable": ^4.8.0
+    "@venusprotocol/governance-contracts": ^2.0.0
+    "@venusprotocol/protocol-reserve": ^2.0.0
+    "@venusprotocol/solidity-utilities": ^2.0.1
+    "@venusprotocol/token-bridge": ^2.0.0
+    bignumber.js: ^9.1.2
+    dotenv: ^16.0.1
+    module-alias: ^2.2.2
+  checksum: d6520c254944bf85b157d0d771ef4bafe75f31a9879f724ae9b68564ab216b8977d3dc3dd245cb3c04a2318866ce11c6ce78ea4aeddb4893fe4f90c6fc683fae
   languageName: node
   linkType: hard
 
@@ -20469,7 +20554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.0":
+"tiny-invariant@npm:^1.1.0, tiny-invariant@npm:^1.3.0":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe


### PR DESCRIPTION
This PR adds BatchTokenConverterOperator – an experimental contract that allows to:

1. Perform conversions in batches
2. Sponsor conversions with Permit2-style permits
3. Call external contracts before, after, or between any other actions (e.g. to reduce BNB reserves or push tokens from ProtocolShareReserve)

This contract may or may not replace the original TokenConverterOperator, depending on how whether these new features prove to be useful enough to sacrifice the ease of use.