### PR TITLE
fix: set interpreter as bash

### DIFF
--- a/packages/cli/prepare.sh
+++ b/packages/cli/prepare.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env
+#!/bin/bash
 
 yarn

--- a/packages/smart-contracts/prepare.sh
+++ b/packages/smart-contracts/prepare.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env
+#!/bin/bash
 
 yarn

--- a/packages/token-converter-bot/prepare.sh
+++ b/packages/token-converter-bot/prepare.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env
+#!/bin/bash
 
 yarn


### PR DESCRIPTION
Interpreter was incorrectly set as as env. It should be bash