### PR TITLE
refactor: move custom get trade logic to bot

### DIFF
--- a/packages/cli/source/commands/convert.tsx
+++ b/packages/cli/source/commands/convert.tsx
@@ -234,6 +234,16 @@ export default function Convert({ options }: Props) {
             } else if (trade) {
               await tokenConverter.arbitrage(t.tokenConverter, trade, amount, minIncome);
             }
+          } else {
+            dispatch({
+              error: `Swap amount too low (${assetOutUsdValue} USD)`,
+              type: "GetBestTrade",
+              context: {
+                converter: t.tokenConverter,
+                tokenToReceiveFromConverter: t.assetOut.address,
+                tokenToSendToConverter: t.assetIn.address,
+              },
+            });
           }
         }
       } while (loop);

--- a/packages/keeper-bots/src/converter-bot/TokenConverter.test.ts
+++ b/packages/keeper-bots/src/converter-bot/TokenConverter.test.ts
@@ -165,7 +165,7 @@ describe("Token Converter", () => {
     });
 
     test("should call getBestTrade again if price impact is high with lower amount", async () => {
-      const { subscriberMock, pancakeSwapProvider } = createTokenConverterInstance();
+      const { subscriberMock, pancakeSwapProvider, tokenConverter } = createTokenConverterInstance();
 
       const pancakeSwapProviderMock = jest
         .spyOn(PancakeSwapProvider.prototype, "getBestTrade")
@@ -180,7 +180,20 @@ describe("Token Converter", () => {
         return new Percent(9n, 1000n);
       });
 
-      const [trade] = await pancakeSwapProvider.getBestTrade(
+      (publicClient.simulateContract as unknown as jest.Mock).mockImplementation(
+        jest.fn(() => {
+          if (called) {
+            return {
+              result: [1000000000000000000n, 750000000000000000n],
+            };
+          }
+          return {
+            result: [1000000000000000000n, 1000000000000000000n],
+          };
+        }),
+      );
+
+      const [trade] = await tokenConverter.getBestTrade(
         addresses.USDCPrimeConverter,
         addresses.WBNB,
         addresses.USDC,
@@ -231,7 +244,6 @@ describe("Token Converter", () => {
 
       expect(pancakeSwapProviderMock).toHaveBeenNthCalledWith(
         3,
-        addresses.USDCPrimeConverter,
         addresses.WBNB,
         addresses.USDC,
         750000000000000000n,

--- a/packages/keeper-bots/src/providers/swap-provider.ts
+++ b/packages/keeper-bots/src/providers/swap-provider.ts
@@ -1,3 +1,4 @@
+import { Percent } from "@pancakeswap/sdk";
 import { Token } from "@uniswap/sdk-core";
 import { Pool } from "@uniswap/v3-sdk";
 import { Address } from "viem";
@@ -46,8 +47,6 @@ class SwapProvider {
 
   async getBestTrade(
     // eslint-disable-next-line
-    tokenConverter: Address,
-    // eslint-disable-next-line
     swapFrom: Address,
     // eslint-disable-next-line
     swapTo: Address,
@@ -55,7 +54,7 @@ class SwapProvider {
     amount: bigint,
     // eslint-disable-next-line
     fixedPairs?: boolean,
-  ): Promise<[TradeRoute, bigint]> {
+  ): Promise<[TradeRoute, Percent | null]> {
     throw new Error("Not Implemented Error");
   }
 }


### PR DESCRIPTION
Moves custom get Trade logic ( for example fetching trade amount to bot) and out of liquidity provider