### PR TITLE
chore: update release rules

### DIFF
--- a/packages/cli/.releaserc
+++ b/packages/cli/.releaserc
@@ -16,7 +16,7 @@
           },
           {
             "type": "chore",
-            "release": false
+            "release": "minor"
           },
           {
             "type": "docs",

--- a/packages/keeper-bots/.releaserc
+++ b/packages/keeper-bots/.releaserc
@@ -16,7 +16,7 @@
           },
           {
             "type": "chore",
-            "release": false
+            "release": "minor"
           },
           {
             "type": "docs",


### PR DESCRIPTION
## Changes

- Updated release rules. `chore` commits are useful to update dependencies that might be faulty, which then can trigger a release.